### PR TITLE
[tracker] Improve sorting by timestamp. JB#55106 OMP#JOLLA-289

### DIFF
--- a/rpm/0001-Always-insert-timestamps-into-the-database-as-string.patch
+++ b/rpm/0001-Always-insert-timestamps-into-the-database-as-string.patch
@@ -1,0 +1,42 @@
+From 850a7e8275e74b4d8155ac3976e63da0bed50dbd Mon Sep 17 00:00:00 2001
+From: Andrew den Exter <andrew.den.exter@qinetic.com.au>
+Date: Tue, 17 Aug 2021 00:48:01 +0000
+Subject: [PATCH] Always insert timestamps into the database as strings.
+
+---
+ src/libtracker-data/tracker-data-update.c | 18 ++++--------------
+ 1 file changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/src/libtracker-data/tracker-data-update.c b/src/libtracker-data/tracker-data-update.c
+index 0de77755d..2b28a9ad2 100644
+--- a/src/libtracker-data/tracker-data-update.c
++++ b/src/libtracker-data/tracker-data-update.c
+@@ -771,21 +771,11 @@ statement_bind_gvalue (TrackerDBStatement *stmt,
+ 	default:
+ 		if (type == G_TYPE_DATE_TIME) {
+ 			GDateTime *datetime = g_value_get_boxed (value);
++			gchar *str;
+ 
+-			/* If we have anything that prevents a unix timestamp to be
+-			 * lossless, we use the ISO8601 string.
+-			 */
+-			if (g_date_time_get_utc_offset (datetime) != 0 ||
+-			    g_date_time_get_microsecond (datetime) != 0) {
+-				gchar *str;
+-
+-				str = tracker_date_format_iso8601 (datetime);
+-				tracker_db_statement_bind_text (stmt, (*idx)++, str);
+-				g_free (str);
+-			} else {
+-				tracker_db_statement_bind_int (stmt, (*idx)++,
+-				                               g_date_time_to_unix (datetime));
+-			}
++			str = tracker_date_format_iso8601 (datetime);
++			tracker_db_statement_bind_text (stmt, (*idx)++, str);
++			g_free (str);
+ 		} else if (type == G_TYPE_BYTES) {
+ 			GBytes *bytes;
+ 			gconstpointer data;
+-- 
+2.26.2
+

--- a/rpm/tracker.spec
+++ b/rpm/tracker.spec
@@ -5,6 +5,7 @@ Release:    1
 License:    LGPLv2+ and GPLv2+
 URL:        https://wiki.gnome.org/Projects/Tracker
 Source0:    %{name}-%{version}.tar.bz2
+Patch1:     0001-Always-insert-timestamps-into-the-database-as-string.patch
 
 BuildRequires:  meson >= 0.50
 BuildRequires:  vala-devel >= 0.16


### PR DESCRIPTION
Date time values were conditionally stored as either seconds from unix
epoch integers or ISO 8601 strings depending on whether the source date
time included microseconds or time zone offset data that could not be
encoded in an integer.

To resolve these types not being directly comparable a transform
function SparqlTimestamp is applied to the index created for date time
columns. But sorting query results using a pre-constructed index is an
optimization that is selectively utilized by sqlite because it is only
an optimization sometimes. And for queries where it is not an
optimization the result set will fall back to sorting on the column data
directly, which means comparing integers to strings with no context and
the integer values mostly end up sorting after the strings (everything's
a string in sqlite still).

Always storing the timestamp as an ISO 8601 string is the smallest
change that will produce mainly sane results. Date times with time zone
offsets will sort by local time, which is (probably) not desirable but
its an improvement on completely partioning with time zone values from
without. A logical next to resolve that issue would be to specify a
collation function that converted to utc which could then be installed
on the column itself, and not the just the indepedent index. That's a
schema change though.