### PR TITLE
Update to 3.9.2

### DIFF
--- a/rpm/0001-Always-insert-timestamps-into-the-database-as-string.patch
+++ b/rpm/0001-Always-insert-timestamps-into-the-database-as-string.patch
@@ -4,14 +4,14 @@ Date: Tue, 17 Aug 2021 00:48:01 +0000
 Subject: [PATCH] Always insert timestamps into the database as strings.
 
 ---
- src/libtracker-data/tracker-data-update.c | 18 ++++--------------
+ src/libtinysparql/core/tracker-data-update.c | 18 ++++--------------
  1 file changed, 4 insertions(+), 14 deletions(-)
 
-diff --git a/src/libtracker-data/tracker-data-update.c b/src/libtracker-data/tracker-data-update.c
-index 6aa65c9117ed66ff7e801eecaf812315efa9248b..6ed966299b975cc04d7f60a7bc52cea490306d66 100644
---- a/src/libtracker-data/tracker-data-update.c
-+++ b/src/libtracker-data/tracker-data-update.c
-@@ -782,21 +782,11 @@ statement_bind_gvalue (TrackerDBStatement *stmt,
+diff --git a/src/libtinysparql/core/tracker-data-update.c b/src/libtinysparql/core/tracker-data-update.c
+index 7ac3ef600..157826cdf 100644
+--- a/src/libtinysparql/core/tracker-data-update.c
++++ b/src/libtinysparql/core/tracker-data-update.c
+@@ -1099,21 +1099,11 @@ statement_bind_gvalue (TrackerDBStatement *stmt,
  	default:
  		if (type == G_TYPE_DATE_TIME) {
  			GDateTime *datetime = g_value_get_boxed (value);
@@ -25,14 +25,14 @@ index 6aa65c9117ed66ff7e801eecaf812315efa9248b..6ed966299b975cc04d7f60a7bc52cea4
 -				gchar *str;
 -
 -				str = tracker_date_format_iso8601 (datetime);
--				tracker_db_statement_bind_text (stmt, (*idx)++, str);
+-				tracker_db_statement_bind_text (stmt, idx, str);
 -				g_free (str);
 -			} else {
--				tracker_db_statement_bind_int (stmt, (*idx)++,
+-				tracker_db_statement_bind_int (stmt, idx,
 -				                               g_date_time_to_unix (datetime));
 -			}
 +			str = tracker_date_format_iso8601 (datetime);
-+			tracker_db_statement_bind_text (stmt, (*idx)++, str);
++			tracker_db_statement_bind_text (stmt, idx, str);
 +			g_free (str);
  		} else if (type == G_TYPE_BYTES) {
  			GBytes *bytes;

--- a/rpm/0002-portal-Allow-D-Bus-activation-only-through-systemd.patch
+++ b/rpm/0002-portal-Allow-D-Bus-activation-only-through-systemd.patch
@@ -12,12 +12,12 @@ Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/portal/org.freedesktop.portal.Tracker.service.in b/src/portal/org.freedesktop.portal.Tracker.service.in
-index 0894a108dce87632c7aa228e10df69595fbd4f37..60140502274178d8b8652a25e4878f7f3f1bbf33 100644
+index b9f0e030d..ff3b41644 100644
 --- a/src/portal/org.freedesktop.portal.Tracker.service.in
 +++ b/src/portal/org.freedesktop.portal.Tracker.service.in
 @@ -1,4 +1,4 @@
  [D-BUS Service]
  Name=org.freedesktop.portal.Tracker
--Exec=@libexecdir@/tracker-xdg-portal-3
+-Exec=@libexecdir@/tinysparql-xdg-portal-3
 +Exec=/bin/false
- SystemdService=tracker-xdg-portal-3.service
+ SystemdService=tinysparql-xdg-portal-3.service

--- a/rpm/remove-tracker2-db.sh
+++ b/rpm/remove-tracker2-db.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-rm -rf ~/.cache/tracker
-rm -rf ~/.local/share/tracker

--- a/rpm/tinysparql.spec
+++ b/rpm/tinysparql.spec
@@ -1,9 +1,9 @@
-Name:       tracker
+Name:       tinysparql
 Summary:    Desktop-neutral metadata database and search tool
 Version:    3.9.2
 Release:    1
 License:    LGPLv2+ and GPLv2+
-URL:        https://gnome.pages.gitlab.gnome.org/tracker/
+URL:        https://gnome.pages.gitlab.gnome.org/tinysparql/
 Source0:    %{name}-%{version}.tar.bz2
 Patch1:     0001-Always-insert-timestamps-into-the-database-as-string.patch
 Patch2:     0002-portal-Allow-D-Bus-activation-only-through-systemd.patch
@@ -31,8 +31,11 @@ Requires:   systemd-user-session-targets
 Requires(post):   /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 
+Obsoletes:      tracker < 3.8
+Provides:       tracker = %{version}-%{release}
+
 %description
-Tracker is a powerful desktop-neutral first class object database,
+Tinysparql is a powerful desktop-neutral first class object database,
 tag/metadata database and search tool.
 
 It consists of a common object database that allows entities to have an
@@ -43,11 +46,12 @@ links to other entities.
 It provides additional features for file based objects including context
 linking and audit trails for a file object.
 
-Metadata indexers are provided by the tracker-miners package.
+Metadata indexers are provided by the localsearch package.
 
 %package devel
 Summary:    Development files for %{name}
 Requires:   %{name} = %{version}-%{release}
+Obsoletes:  tracker-devel < 3.8
 
 %description devel
 Development files for %{name}.

--- a/rpm/tracker.spec
+++ b/rpm/tracker.spec
@@ -1,11 +1,10 @@
 Name:       tracker
 Summary:    Desktop-neutral metadata database and search tool
-Version:    3.3.3
+Version:    3.9.2
 Release:    1
 License:    LGPLv2+ and GPLv2+
 URL:        https://gnome.pages.gitlab.gnome.org/tracker/
 Source0:    %{name}-%{version}.tar.bz2
-Source1:    remove-tracker2-db.sh
 Patch1:     0001-Always-insert-timestamps-into-the-database-as-string.patch
 Patch2:     0002-portal-Allow-D-Bus-activation-only-through-systemd.patch
 
@@ -22,17 +21,15 @@ BuildRequires:  pkgconfig(glib-2.0) >= 2.46.0
 BuildRequires:  pkgconfig(icu-uc)
 BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(libxml-2.0) >= 2.6
-BuildRequires:  pkgconfig(libsoup-2.4) >= 2.40
+BuildRequires:  pkgconfig(libsoup-3.0)
 BuildRequires:  pkgconfig(sqlite3) >= 3.11
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(json-glib-1.0) >= 1.0
 BuildRequires:  python3-gobject
-BuildRequires:  oneshot
 
 Requires:   systemd-user-session-targets
 Requires(post):   /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
-%{_oneshot_requires_post}
 
 %description
 Tracker is a powerful desktop-neutral first class object database,
@@ -60,6 +57,7 @@ Development files for %{name}.
 
 %build
 %meson -Dman=false -Ddocs=false \
+       -Davahi=disabled \
        -Dstemmer=disabled \
        -Dunicode_support=icu \
        -Dbash_completion=false \
@@ -70,46 +68,37 @@ Development files for %{name}.
 %install
 %meson_install
 
-install -D -m 755 %{SOURCE1} %{buildroot}/%{_oneshotdir}/remove-tracker2-db.sh
+%find_lang tinysparql3
 
-%find_lang tracker3
+%post -p /sbin/ldconfig
 
-%post
-/sbin/ldconfig
+%postun -p /sbin/ldconfig
 
-if [ "$1" -ge 1 ]; then
-add-oneshot --all-users remove-tracker2-db.sh || :
-fi
-
-%postun
-/sbin/ldconfig
-
-%files -f tracker3.lang
-%defattr(-,root,root,-)
+%files -f tinysparql3.lang
 %license COPYING COPYING.LGPL COPYING.GPL
-%{_bindir}/tracker3
-%{_libexecdir}/tracker3/
-%{_libexecdir}/tracker-xdg-portal-3
-%{_libdir}/libtracker-sparql-*.so.*
-%{_libdir}/tracker-3.0/libtracker-remote-soup2.so
+%{_bindir}/tinysparql
+%{_libexecdir}/tinysparql-sql
+%{_libexecdir}/tinysparql-xdg-portal-3
+%{_libdir}/libtinysparql-3.0.so.0*
+%{_libdir}/tinysparql-3.0/
 %{_datadir}/dbus-1/services/org.freedesktop.portal.Tracker.service
-%{_datadir}/tracker3/stop-words/
-%{_datadir}/tracker3/ontologies/
-%{_userunitdir}/tracker-xdg-portal-3.service
-%attr(0755, -, -) %{_oneshotdir}/remove-tracker2-db.sh
+%{_userunitdir}/tinysparql-xdg-portal-3.service
 
 %files devel
-%defattr(-,root,root,-)
 %doc AUTHORS NEWS README.md
-%{_includedir}/tracker-3.0/
-%{_libdir}/libtracker-sparql-*.so
-%{_libdir}/pkgconfig/*.pc
+%{_includedir}/tinysparql-3.0/
+%{_libdir}/libtinysparql-3.0.so
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/Tracker-3.0.typelib
+%{_libdir}/girepository-1.0/Tsparql-3.0.typelib
 %dir %{_datadir}/vala
 %dir %{_datadir}/vala/vapi
 %{_datadir}/vala/vapi/tracker*.deps
 %{_datadir}/vala/vapi/tracker*.vapi
+%{_libdir}/pkgconfig/tinysparql-3.0.pc
+%{_libdir}/pkgconfig/tracker-sparql-3.0.pc
+%{_datadir}/vala/vapi/tinysparql-3.0.deps
+%{_datadir}/vala/vapi/tinysparql-3.0.vapi
 %dir %{_datadir}/gir-1.0
 %{_datadir}/gir-1.0/Tracker-3.0.gir
-%{_libdir}/tracker-3.0/trackertestutils/
+%{_datadir}/gir-1.0/Tsparql-3.0.gir


### PR DESCRIPTION
Project renamed upstream to tinysparql. Here renaming the .spec in separate commit. We should be moving also the repository so didn't yet make the .spec url point here.

Removed also the tracker 2.x database removal oneshot. It should have served its purpose by now.